### PR TITLE
Replace `edge-cpu` RedisAI tag with `latest` as former does not exist.

### DIFF
--- a/ml/charts/kubeml/templates/storage.yaml
+++ b/ml/charts/kubeml/templates/storage.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
         - name: redisai
-          image: redislabs/redisai:edge-cpu
+          image: redislabs/redisai:latest
           ports:
             - containerPort: 6379
 


### PR DESCRIPTION
Replace the RedisAI container image tag from `redislabs/redisai:edge-cpu` to `redislabs/redisai:latest` as the former does not exist.